### PR TITLE
Allow trailing comment when an argument list ends on its own line

### DIFF
--- a/autoload/coiledsnake.vim
+++ b/autoload/coiledsnake.vim
@@ -399,7 +399,7 @@ function! s:InitLine(lnum, state) abort "{{{1
     " formatter, see issues #4, #8, #12.  Note that this would be taken care 
     " automatically if the above logic could handle open parentheses.  
 
-    if line.text =~# '^\s*)\s*\(->\s*.\+\)\?:\s*$'
+    if line.text =~# '^\s*)\s*\(->\s*.\+\)\?:\s*\(#.\+\)\?$'
       let line.is_code = 0
     endif
 

--- a/tests/corner_cases/comment_after_function.py
+++ b/tests/corner_cases/comment_after_function.py
@@ -1,0 +1,18 @@
+# Related to #22. Adding a lone # after a function sould prevent folding as in
+# test_ignore.py. Here, including more text after the # (like a comment, or
+# code to prevent a linting message), should allow it to fold again. Including
+# another # at the end of the line should still prevent folding.
+
+def foo(): # comment here should still fold
+    pass
+
+def foo(): # trailing # still prevents folding #
+    pass
+
+@decorator
+def foo(): # comment here should still fold
+    pass
+
+@decorator
+def foo(): # trailing # still prevents folding #
+    pass


### PR DESCRIPTION
When handling the case where a long argument list ends on its own line
at the same indentation level as 'def', allow a trailing comment on that
line. This commit adds \(#.\+\)\? to the end of the regex that handles
this case. The \+ is required so that this change doesn't interfere with
s:manual_open_pattern, where a lone trailing # will prevent folding on
that line.

def this_will_fold_properly_now(
    arg1,
    arg2,
    arg3,
): # some comment
    pass

def this_will_still_prevent_folding(
    arg1,
    arg2,
    arg3,
): #
    pass