### PR TITLE
Fix detection of signcolumn

### DIFF
--- a/autoload/coiledsnake.vim
+++ b/autoload/coiledsnake.vim
@@ -675,7 +675,7 @@ function! s:BufferWidth() abort "{{{1
     elseif &signcolumn == 'auto'
         " The `:sign place` output contains two header lines.
         " The sign column is fixed at two columns, if present.
-        let signlist = execute(printf('sign place buffer=%d', bufnr('')))
+        let signlist = execute(printf('sign place group=* buffer=%d', bufnr('')))
         let signlist = split(signlist, "\n")
         let signwidth = len(signlist) > 2 ? 2 : 0
     else


### PR DESCRIPTION
https://github.com/kalekundert/vim-coiled-snake/issues/16#issuecomment-596234471

> For some reason, though, :sign place does not return the signs placed by vim-gitgutter

See the diff in my commit. You will understand why it wasn't showing.