### PR TITLE
Improve signcolumn detection

### DIFF
--- a/autoload/coiledsnake.vim
+++ b/autoload/coiledsnake.vim
@@ -675,7 +675,8 @@ function! s:BufferWidth() abort "{{{1
     elseif &signcolumn == 'auto'
         " The `:sign place` output contains two header lines.
         " The sign column is fixed at two columns, if present.
-        let signlist = execute(printf('sign place buffer=%d', bufnr('')))
+        let supports_sign_groups = has('nvim-0.4.2') || has('patch-8.1.614')
+        let signlist = execute(printf('sign place ' . (supports_sign_groups ? 'group=* ' : '') . 'buffer=%d', bufnr('')))
         let signlist = split(signlist, "\n")
         let signwidth = len(signlist) > 2 ? 2 : 0
     else

--- a/autoload/coiledsnake.vim
+++ b/autoload/coiledsnake.vim
@@ -672,6 +672,12 @@ function! s:BufferWidth() abort "{{{1
         let signwidth = g:coiled_snake_explicit_sign_width
     elseif &signcolumn == 'yes'
         let signwidth = 2
+    elseif &signcolumn =~ 'yes'
+        let signwidth = &signcolumn
+        if signwidth =~ ':'
+            let signwidth = split(signwidth, ':')[1]
+        endif
+        let signwidth *= 2  " each signcolumn is 2-char wide
     elseif &signcolumn == 'auto'
         " The `:sign place` output contains two header lines.
         " The sign column is fixed at two columns, if present.
@@ -679,6 +685,17 @@ function! s:BufferWidth() abort "{{{1
         let signlist = execute(printf('sign place ' . (supports_sign_groups ? 'group=* ' : '') . 'buffer=%d', bufnr('')))
         let signlist = split(signlist, "\n")
         let signwidth = len(signlist) > 2 ? 2 : 0
+    elseif &signcolumn =~ 'auto'    " i.e. neovim
+        let signwidth = 0
+        if len(sign_getplaced(bufnr(),{'group':'*'})[0].signs) " signs exist
+            let signwidth = 0
+            for l:sign in sign_getplaced(bufnr(),{'group':'*'})[0].signs
+                let lnum = l:sign.lnum
+                let signs = len(sign_getplaced(bufnr(),{'group':'*', 'lnum':lnum})[0].signs)
+                let signwidth = (signs > signwidth ? signs : signwidth)
+            endfor
+        endif
+        let signwidth *= 2  " each signcolumn is 2-char wide
     else
         let signwidth = 0
     endif
@@ -686,4 +703,4 @@ function! s:BufferWidth() abort "{{{1
     return width - numwidth - foldwidth - signwidth
 endfunction
 
-" vim: ts=4 sts=4 sw=4 fdm=marker
+" vim: ts=4 sts=4 sw=4 fdm=marker et


### PR DESCRIPTION
Ping @kalekundert 
I missed to mention in the last PR that sign groups are a relatively new feature. So, I added a check in this PR

The check has been taken from w0rp/ale

https://github.com/dense-analysis/ale/blob/48fe0dd4f629bb1282277ba8a6757a84c13a4dda/autoload/ale/sign.vim#L26
https://github.com/dense-analysis/ale/blob/48fe0dd4f629bb1282277ba8a6757a84c13a4dda/autoload/ale/sign.vim#L161-L167
https://github.com/dense-analysis/ale/blob/48fe0dd4f629bb1282277ba8a6757a84c13a4dda/autoload/ale/sign.vim#L170-L174